### PR TITLE
Explicitly set kubernetes versions to avoid breaking API changes

### DIFF
--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -2,7 +2,9 @@ kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
 nodes:
 - role: control-plane
+  image: kindest/node:v1.15.7
 - role: worker
+  image: kindest/node:v1.15.7
   extraPortMappings:
   - containerPort: 5900
     hostPort: 5900


### PR DESCRIPTION
Master's README currently doesn't work with the latest KIND image, kubernetes v1.16, due to api changes. Let's explictly declare kind to run as 1.15 or update the manifests accordingly and then set the version

Example failure mode:
```
 ryanhartje@ryans-mbp  ~/go/src/github.com/storax/kubedoom   master  kubectl apply -f manifest/
namespace/kubedoom created
serviceaccount/kubedoom created
clusterrolebinding.rbac.authorization.k8s.io/kubedoom created
error: unable to recognize "manifest/deployment.yaml": no matches for kind "Deployment" in version "apps/v1beta2"
```