### PR TITLE
Fix buffer overflow in LoadDefaultCollection

### DIFF
--- a/dockerdoom/trunk/setup/configfile.c
+++ b/dockerdoom/trunk/setup/configfile.c
@@ -512,7 +512,7 @@ static void LoadDefaultCollection(default_collection_t *collection)
     
     while (!feof(f))
     {
-        if (fscanf (f, "%79s %[^\n]\n", defname, strparm) != 2)
+        if (fscanf (f, "%79s %99[^\n]\n", defname, strparm) != 2)
         {
             // This line doesn't match
           

--- a/dockerdoom/trunk/src/m_config.c
+++ b/dockerdoom/trunk/src/m_config.c
@@ -1312,7 +1312,7 @@ static void LoadDefaultCollection(default_collection_t *collection)
     
     while (!feof(f))
     {
-        if (fscanf (f, "%79s %[^\n]\n", defname, strparm) != 2)
+        if (fscanf (f, "%79s %99[^\n]\n", defname, strparm) != 2)
         {
             // This line doesn't match
           


### PR DESCRIPTION
If `fscanf` doesn't limit the number of characters to be read, it can lead to a buffer overflow which allows for arbitrary code execution. 

CVE-2020-15007: https://nvd.nist.gov/vuln/detail/CVE-2020-15007