### PR TITLE
ARM64 Support, GitHub Actions Workflow

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,32 @@
+---
+name: Container Build
+
+on:
+  push:
+    tags: ['[0-9]+.[0-9]+.[0-9]+']
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: |-
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,56 +1,57 @@
-FROM golang:1.14-alpine AS gobuild
-
+FROM golang:1.17-alpine AS build-kubedoom
 WORKDIR /go/src/kubedoom
+ADD go.mod .
 ADD kubedoom.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o kubedoom .
 
-FROM ubuntu:20.10 AS ubuntu
-# make sure the package repository is up to date
-RUN apt-get update
-
-FROM ubuntu AS ubuntu-deps
-# Install dependencies
-RUN apt-get install -y \
+FROM ubuntu:21.10 AS build-essentials
+ARG TARGETARCH
+ARG KUBECTL_VERSION=1.23.2
+RUN apt-get update && apt-get install -y \
   -o APT::Install-Suggests=0 \
   --no-install-recommends \
   wget ca-certificates
 RUN wget http://distro.ibiblio.org/pub/linux/distributions/slitaz/sources/packages/d/doom1.wad
-RUN wget -O /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(wget -O- https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+RUN echo "TARGETARCH is $TARGETARCH"
+RUN echo "KUBECTL_VERSION is $KUBECTL_VERSION"
+RUN wget -O /usr/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
   && chmod +x /usr/bin/kubectl
 
-FROM ubuntu AS ubuntu-build
-
+FROM ubuntu:21.10 AS build-doom
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
   -o APT::Install-Suggests=0 \
   --no-install-recommends \
   build-essential \
   libsdl-mixer1.2-dev \
   libsdl-net1.2-dev \
   gcc
-
-# Setup doom
 ADD /dockerdoom /dockerdoom
-RUN cd /dockerdoom/trunk && ./configure && make && make install
+WORKDIR /dockerdoom/trunk
+RUN ./configure && make && make install
 
-FROM ubuntu
-RUN apt-get install -y \
+FROM ubuntu:21.10 as build-converge
+WORKDIR /build
+RUN mkdir -p \
+  /build/root \
+  /build/usr/bin \
+  /build/usr/local/games
+COPY --from=build-essentials /doom1.wad /build/root
+COPY --from=build-essentials /usr/bin/kubectl /build/usr/bin
+COPY --from=build-kubedoom /go/src/kubedoom/kubedoom /build/usr/bin
+COPY --from=build-doom /usr/local/games/psdoom /build/usr/local/games
+
+FROM ubuntu:21.10
+RUN apt-get update && apt-get install -y \
   -o APT::Install-Suggests=0 \
   --no-install-recommends \
   libsdl-mixer1.2 \
   libsdl-net1.2 \
   x11vnc \
   xvfb \
-  netcat-openbsd
-
-WORKDIR /root/
-
-# Setup a password
-RUN mkdir ~/.vnc && x11vnc -storepasswd idbehold ~/.vnc/passwd
-
-COPY --from=ubuntu-deps /doom1.wad .
-COPY --from=ubuntu-deps /usr/bin/kubectl /usr/bin/
-COPY --from=ubuntu-build /usr/local/games/psdoom /usr/local/games/
-COPY --from=gobuild /go/src/kubedoom/kubedoom .
-
-ENTRYPOINT ["/root/kubedoom"]
+  netcat-openbsd \
+  && rm -rf /var/lib/apt/lists/*
+RUN mkdir /root/.vnc && x11vnc -storepasswd idbehold /root/.vnc/passwd
+COPY --from=build-converge /build /
+WORKDIR /root
+ENTRYPOINT ["/usr/bin/kubedoom"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module kubedoom
+
+go 1.17

--- a/manifest/deployment.yaml
+++ b/manifest/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,8 +19,11 @@ spec:
       hostNetwork: true
       serviceAccountName: kubedoom
       containers:
-      - image: storaxdev/kubedoom:0.5.0
-        name: kubedoom
-        ports:
-        - containerPort: 5900
-          name: vnc
+        - image: ghcr.io/storax/kubedoom:latest
+          env:
+            - name: NAMESPACE
+              value: default
+          name: kubedoom
+          ports:
+            - containerPort: 5900
+              name: vnc

--- a/manifest/kustomization.yaml
+++ b/manifest/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 resources:
   - namespace.yaml
   - deployment.yaml

--- a/manifest/namespace.yaml
+++ b/manifest/namespace.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/manifest/rbac.yaml
+++ b/manifest/rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Changes:
- Added GitHub Actions
  - Builds when a new SemVer compliant tag gets created, e.g. `git tag 0.5.1 && git push --tags`
- Build with Go 1.17
- Switch to Ubuntu 21.10
- Lower number of layers in output image
- Build `linux/amd64` and `linux/arm64` images
- Ran `yamlfix` over the deployment files